### PR TITLE
Solve #2, clicking outside element closes it.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name" : "Switcheroo",
     "description" : "Fuzzy-navigate between open tabs",
-    "version" : "0.0.1",
+    "version" : "0.0.2",
 
     "background" : {
         "scripts" : ["src/background.js"],

--- a/src/background.js
+++ b/src/background.js
@@ -45,4 +45,4 @@ chrome.runtime.onConnect.addListener(function runtime$onConnect (port) {
     // TAAAAAAAAAAAAAAAAAAAAAAAAAABS
 });
 
-console.log('yeepee');
+//console.log('yeepee');

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -86,6 +86,17 @@ function planTheSwitcheroo (tabs) {
         }
     };
 
+    function hasAncestor(element, target) {
+        if (element === document.documentElement) { return false; }
+        return element === target || hasAncestor(element.parentNode, target);
+    }
+
+    document.addEventListener('click', function document$click(e) {
+        if (!hasAncestor(e.target, container)) {
+            container.remove();
+        }
+    });
+
     container.input.onkeydown = function input$onkeydown (e) {
         var identifier = e.keyIdentifier;
         if (e.which === 27) {


### PR DESCRIPTION
Add event listener on document to close switcheroo when clicked outside
of it.
Comment out "yeepee" console.log, it was causing errors.
Bump manifest version to 0.0.2.
